### PR TITLE
index.js - Generate the ast before exiting the core processing phase.…

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function toc_plugin(md, options) {
 		format: undefined
 	}, options);
 
-	let final_state;
+	let final_ast;
 
 	function toc(state, startLine/*, endLine, silent*/) {
 		let token;
@@ -73,7 +73,7 @@ module.exports = function toc_plugin(md, options) {
 	}
 
 	md.renderer.rules.toc_body = function(/*tokens, idx, options, env, renderer*/) {
-		return ast_html( headings_ast( final_state.tokens ) );
+		return ast_html(final_ast);
 	}
 
 	function ast_html(tree, uniques) {
@@ -132,7 +132,8 @@ module.exports = function toc_plugin(md, options) {
 	}
 
 	md.core.ruler.push("final_state", function(state){
-		final_state = state;
+		const tokens = state.tokens
+		final_ast = headings_ast(tokens)
 	});
 
 	md.block.ruler.before("heading", "toc", toc, {


### PR DESCRIPTION
I ran into this when fixing markdown-it-hierarchy. After looking at the approach of modifying content during the core phase I switched back to having the plugin operate at the rendering phase.

This plugin adds numbers to headers, like "1. Some header", and "1.1 Some nested header" for a header nested under the first etc.

What was occurring was that markdown-it-hierarchy (the new version I haven't pushed out yet), was adding "1." to the first entry in my markdown, making it "1. Table of contents". Then, the next token was the toc token which this plugin would process. In the act of processing the ast would be built up which would consist of:

```
1. Table of contents
...
The next header after the table of contents
The next header after that
```

And the toc would contain an odd first entry like:

```
1. 1. Table of contents
2. The next header after the table of contents
3. The next header after that
```

So I was thinking a fix for this would be to capture the ast after the core phase (although I'm not sure how to ensure we are doing that), and before my plugin altered the tokens during rendering.

It may make sense for my plugin not to modify the tokens during rendering but I'm not sure how best to do that at the moment.

Thoughts on this change?
