### PR TITLE
Support Array for Level option

### DIFF
--- a/__test__/test.js
+++ b/__test__/test.js
@@ -46,7 +46,12 @@ const level_md = require("markdown-it")({
 
 
 
-
+  const level_md_array = require("markdown-it")({
+	html: false,
+	xhtmlOut: true,
+	typographer: true
+}).use( require("markdown-it-anchor"), { permalink: true, permalinkBefore: true, permalinkSymbol: '§', level: [1, 2] } )
+  .use( require("../index.js"), { level: [1, 2] } );
 
 
 
@@ -139,10 +144,20 @@ test("and sometimes slugify with suffix may generate another existing header", (
 `);
 });
 
-test("level option should work as expected", () => {
+test("level(Int Type) option should work as expected", () => {
 	expect( level_md.render("${toc}\n\n# header\n\n## header\n\n## header 2") ).toBe(`<nav class="table-of-contents"><ol><li><a href="#header"> header</a></li><li><a href="#header-2"> header 2</a></li></ol></nav><h1>header</h1>
 <h2 id="header"><a class="header-anchor" href="#header" aria-hidden="true">§</a> header</h2>
 <h2 id="header-2"><a class="header-anchor" href="#header-2" aria-hidden="true">§</a> header 2</h2>
+`);
+});
+
+test("level(Array Type) option should work as expected", () => {
+	expect( level_md_array.render("${toc}\n\n# header\n\n## header\n\n## header 2\n\n# header 4\n\n## header 5\n\n## header 2") ).toBe(`<nav class="table-of-contents"><ol><li><a href="#header"> header</a><ol><li><a href="#header-2"> header</a></li><li><a href="#header-2-2"> header 2</a></li></ol></li><li><a href="#header-4"> header 4</a><ol><li><a href="#header-5"> header 5</a></li><li><a href="#header-2-3"> header 2</a></li></ol></li></ol></nav><h1 id="header"><a class="header-anchor" href="#header" aria-hidden="true">§</a> header</h1>
+<h2 id="header-2"><a class="header-anchor" href="#header-2" aria-hidden="true">§</a> header</h2>
+<h2 id="header-2-2"><a class="header-anchor" href="#header-2-2" aria-hidden="true">§</a> header 2</h2>
+<h1 id="header-4"><a class="header-anchor" href="#header-4" aria-hidden="true">§</a> header 4</h1>
+<h2 id="header-5"><a class="header-anchor" href="#header-5" aria-hidden="true">§</a> header 5</h2>
+<h2 id="header-2-3"><a class="header-anchor" href="#header-2-3" aria-hidden="true">§</a> header 2</h2>
 `);
 });
 

--- a/index.js
+++ b/index.js
@@ -116,6 +116,14 @@ module.exports = function toc_plugin(md, options) {
 	function headings_ast(tokens) {
 		const ast   = { l: 0, n: "", c: {} };
 		const stack = [ast];
+
+		const isLevelSelectedNumber = selection => level => level >= selection
+		const isLevelSelectedArray = selection => level => selection.includes(level)
+		
+		const isLevelSelected = Array.isArray(options.level)
+      		? isLevelSelectedArray(options.level)
+			  : isLevelSelectedNumber(options.level)
+			  
 		for (let i = 0, iK = tokens.length; i < iK; i++) {
 			const token = tokens[i];
 			if(token.type === "heading_open") {
@@ -127,7 +135,7 @@ module.exports = function toc_plugin(md, options) {
 					c: {}
 				};
 
-				if (node.l >= options.level) {
+				if (isLevelSelected(node.l)) {
 					if ( node.l > stack[0].l ) {
 						stack[0].c[node.n] = node;
 						stack.unshift(node);


### PR DESCRIPTION
Support array type for level option.
I noticed that there is a no code for when level option has array type.
So, I have changed index.js file.