### PR TITLE
Allow markdown-it as a peerDependency in version ^11.0.0 as well

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-toc-done-right",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "uslug": "^1.0.4"
   },
   "peerDependencies": {
-    "markdown-it": "^10.0.0",
+    "markdown-it": "^10.0.0|^11.0.0",
     "markdown-it-anchor": "^5.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "uslug": "^1.0.4"
   },
   "peerDependencies": {
-    "markdown-it": "^10.0.0||^11.0.0",
     "markdown-it-anchor": "^5.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,5 @@
     "snazzy": "^8.0.0",
     "standard": "^13.1.0",
     "uslug": "^1.0.4"
-  },
-  "peerDependencies": {
-    "markdown-it-anchor": "^5.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "uslug": "^1.0.4"
   },
   "peerDependencies": {
-    "markdown-it": "^10.0.0|^11.0.0",
+    "markdown-it": "^10.0.0||^11.0.0",
     "markdown-it-anchor": "^5.2.5"
   }
 }


### PR DESCRIPTION
Fixes #31 by allowing to have `markdown-it` in version `^10.0.0` or `^11.0.0`.