### PR TITLE
Reformat test file

### DIFF
--- a/__test__/test.js
+++ b/__test__/test.js
@@ -1,103 +1,67 @@
-const md = require("markdown-it")({
-	html: false,
-	xhtmlOut: true,
-	typographer: true
-}).use( require("markdown-it-anchor"), { permalink: true, permalinkBefore: true, permalinkSymbol: '§' } )
-  .use( require('../dist/markdownItTocDoneRight.js') );
+/* eslint-env jest */
+/* eslint-disable no-template-curly-in-string */
 
+const markdownIt = require('markdown-it')
+const markdownItAnchor = require('markdown-it-anchor')
+const markdownItTocDoneRight = require('../dist/markdownItTocDoneRight')
+const uslug = require('uslug')
 
-
-
-
-const uslug = require("uslug");
-function uslugify(x) {
-	return uslug(x);
+function getMarkdownIt () {
+  return markdownIt({
+    html: false,
+    xhtmlOut: true,
+    typographer: true
+  })
 }
-function custom_format(x, h) {
-	return `<span>${h(x)}</span>`;
+
+function uslugify (text) {
+  return uslug(text)
 }
-const umd = require("markdown-it")({
-	html: false,
-	xhtmlOut: true,
-	typographer: true
-}).use( require("markdown-it-anchor"), { permalink: true, permalinkBefore: true, permalinkSymbol: '§', slugify: uslugify } )
-  .use( require('../dist/markdownItTocDoneRight.js'), {
-	placeholder: "\\@\\[\\[TOC\\]\\]",
-	slugify: uslugify,
-	containerClass: "user-content-toc",
-	listClass: "my-list",
-	itemClass: "my-item",
-	linkClass: "my-link",
-	listType: "ul",
-	format: custom_format,
-	callback: function (html, ast) {
-		console.log(ast)
-	}
-} );
 
+function customFormat (content, htmlEncoder) {
+  return `<span>${htmlEncoder(content)}</span>`
+}
 
+const commonMd = getMarkdownIt()
+  .use(markdownItAnchor, {
+    permalink: true,
+    permalinkBefore: true,
+    permalinkSymbol: '§'
+  })
+  .use(markdownItTocDoneRight)
 
+test('empty set', () => {
+  const mdContent = '${toc}'
+  const htmlContent = '<nav class="table-of-contents"></nav>'
+  expect(commonMd.render(mdContent)).toBe(htmlContent)
+})
 
-
-const level_md = require("markdown-it")({
-	html: false,
-	xhtmlOut: true,
-	typographer: true
-}).use( require("markdown-it-anchor"), { permalink: true, permalinkBefore: true, permalinkSymbol: '§', level: 2 } )
-  .use( require('../dist/markdownItTocDoneRight.js'), { level: 2 } );
-
-
-
-
-
-const level_md_array = require("markdown-it")({
-	html: false,
-	xhtmlOut: true,
-	typographer: true
-}).use( require("markdown-it-anchor"), { permalink: true, permalinkBefore: true, permalinkSymbol: '§', level: [1, 2] } )
-  .use( require('../dist/markdownItTocDoneRight.js'), { level: [1, 2] } );
-
-
-
-
-
-const containerId_md = require("markdown-it")({
-	html: false,
-	xhtmlOut: true,
-	typographer: true
-}).use( require('../dist/markdownItTocDoneRight.js'), { containerId: "toc" } );
-
-
-
-
-
-test("empty set", () => {
-	expect( md.render("${toc}") ).toBe('<nav class="table-of-contents"></nav>');
-});
-
-test("containerId is set correctly", () => {
-	expect( containerId_md.render("${toc}") ).toBe('<nav id="toc" class="table-of-contents"></nav>');
-});
-
-test("single element", () => {
-	expect( md.render("${toc}\n\n# Title") ).toBe('<nav class="table-of-contents"><ol><li><a href="#title"> Title</a></li></ol></nav><h1 id="title"><a class="header-anchor" href="#title">§</a> Title</h1>\n');
-});
+test('single element', () => {
+  const mdContent = '${toc}\n\n# Title'
+  const htmlContent = '<nav class="table-of-contents"><ol><li><a href="#title"> Title</a></li></ol></nav><h1 id="title"><a class="header-anchor" href="#title">§</a> Title</h1>\n'
+  expect(commonMd.render(mdContent)).toBe(htmlContent)
+})
 
 test("single element doesn't need to be h1", () => {
-	expect( md.render("${toc}\n\n## Section") ).toBe('<nav class="table-of-contents"><ol><li><a href="#section"> Section</a></li></ol></nav><h2 id="section"><a class="header-anchor" href="#section">§</a> Section</h2>\n');
-});
+  const mdContent = '${toc}\n\n## Section'
+  const htmlContent = '<nav class="table-of-contents"><ol><li><a href="#section"> Section</a></li></ol></nav><h2 id="section"><a class="header-anchor" href="#section">§</a> Section</h2>\n'
+  expect(commonMd.render(mdContent)).toBe(htmlContent)
+})
 
-test("main heading usually comes first", () => {
-	expect( md.render("${toc}\n\n# Title\n\n## Section 1\n\n### Sub Section 1\n\n### Sub Section 2\n\n## Section 2") ).toBe(`<nav class="table-of-contents"><ol><li><a href="#title"> Title</a><ol><li><a href="#section-1"> Section 1</a><ol><li><a href="#sub-section-1"> Sub Section 1</a></li><li><a href="#sub-section-2"> Sub Section 2</a></li></ol></li><li><a href="#section-2"> Section 2</a></li></ol></li></ol></nav><h1 id="title"><a class="header-anchor" href="#title">§</a> Title</h1>
+test('main heading usually comes first', () => {
+  const mdContent = '${toc}\n\n# Title\n\n## Section 1\n\n### Sub Section 1\n\n### Sub Section 2\n\n## Section 2'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#title"> Title</a><ol><li><a href="#section-1"> Section 1</a><ol><li><a href="#sub-section-1"> Sub Section 1</a></li><li><a href="#sub-section-2"> Sub Section 2</a></li></ol></li><li><a href="#section-2"> Section 2</a></li></ol></li></ol></nav><h1 id="title"><a class="header-anchor" href="#title">§</a> Title</h1>
 <h2 id="section-1"><a class="header-anchor" href="#section-1">§</a> Section 1</h2>
 <h3 id="sub-section-1"><a class="header-anchor" href="#sub-section-1">§</a> Sub Section 1</h3>
 <h3 id="sub-section-2"><a class="header-anchor" href="#sub-section-2">§</a> Sub Section 2</h3>
 <h2 id="section-2"><a class="header-anchor" href="#section-2">§</a> Section 2</h2>
-`);
-});
+`
+  expect(commonMd.render(mdContent)).toBe(htmlContent)
+})
 
-test("but sometimes it comes after navigation", () => {
-	expect( md.render("${toc}\n\n## Navigation Menu\n\n## Sidebar\n\n### More news\n\n### What our clients say\n\n### Ratings\n\n# Title\n\n## Section 1\n\n### Sub Section 1\n\n### Sub Section 2\n\n## Section 2") ).toBe(`<nav class="table-of-contents"><ol><li><a href="#navigation-menu"> Navigation Menu</a></li><li><a href="#sidebar"> Sidebar</a><ol><li><a href="#more-news"> More news</a></li><li><a href="#what-our-clients-say"> What our clients say</a></li><li><a href="#ratings"> Ratings</a></li></ol></li><li><a href="#title"> Title</a><ol><li><a href="#section-1"> Section 1</a><ol><li><a href="#sub-section-1"> Sub Section 1</a></li><li><a href="#sub-section-2"> Sub Section 2</a></li></ol></li><li><a href="#section-2"> Section 2</a></li></ol></li></ol></nav><h2 id="navigation-menu"><a class="header-anchor" href="#navigation-menu">§</a> Navigation Menu</h2>
+test('but sometimes it comes after navigation', () => {
+  const mdContent = '${toc}\n\n## Navigation Menu\n\n## Sidebar\n\n### More news\n\n### What our clients say\n\n### Ratings\n\n# Title\n\n## Section 1\n\n### Sub Section 1\n\n### Sub Section 2\n\n## Section 2'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#navigation-menu"> Navigation Menu</a></li><li><a href="#sidebar"> Sidebar</a><ol><li><a href="#more-news"> More news</a></li><li><a href="#what-our-clients-say"> What our clients say</a></li><li><a href="#ratings"> Ratings</a></li></ol></li><li><a href="#title"> Title</a><ol><li><a href="#section-1"> Section 1</a><ol><li><a href="#sub-section-1"> Sub Section 1</a></li><li><a href="#sub-section-2"> Sub Section 2</a></li></ol></li><li><a href="#section-2"> Section 2</a></li></ol></li></ol></nav><h2 id="navigation-menu"><a class="header-anchor" href="#navigation-menu">§</a> Navigation Menu</h2>
 <h2 id="sidebar"><a class="header-anchor" href="#sidebar">§</a> Sidebar</h2>
 <h3 id="more-news"><a class="header-anchor" href="#more-news">§</a> More news</h3>
 <h3 id="what-our-clients-say"><a class="header-anchor" href="#what-our-clients-say">§</a> What our clients say</h3>
@@ -107,42 +71,52 @@ test("but sometimes it comes after navigation", () => {
 <h3 id="sub-section-1"><a class="header-anchor" href="#sub-section-1">§</a> Sub Section 1</h3>
 <h3 id="sub-section-2"><a class="header-anchor" href="#sub-section-2">§</a> Sub Section 2</h3>
 <h2 id="section-2"><a class="header-anchor" href="#section-2">§</a> Section 2</h2>
-`);
-});
+`
+  expect(commonMd.render(mdContent)).toBe(htmlContent)
+})
 
-test("markup inside the heading should be treated", () => {
-	expect( md.render("${toc}\n\n# A **heading** with *markup* `code` [link](https://github.com)") ).toBe('<nav class="table-of-contents"><ol><li><a href="#a-heading-with-markup-code-link"> A heading with markup code link</a></li></ol></nav><h1 id="a-heading-with-markup-code-link"><a class="header-anchor" href="#a-heading-with-markup-code-link">§</a> A <strong>heading</strong> with <em>markup</em> <code>code</code> <a href="https://github.com">link</a></h1>\n');
-});
+test('markup inside the heading should be treated', () => {
+  const mdContent = '${toc}\n\n# A **heading** with *markup* `code` [link](https://github.com)'
+  const htmlContent = '<nav class="table-of-contents"><ol><li><a href="#a-heading-with-markup-code-link"> A heading with markup code link</a></li></ol></nav><h1 id="a-heading-with-markup-code-link"><a class="header-anchor" href="#a-heading-with-markup-code-link">§</a> A <strong>heading</strong> with <em>markup</em> <code>code</code> <a href="https://github.com">link</a></h1>\n'
+  expect(commonMd.render(mdContent)).toBe(htmlContent)
+})
 
-test("especially < and >", () => {
-	expect( md.render("${toc}\n\n# > Title\n\n## < Section\n\n## > Another Section") ).toBe(`<nav class="table-of-contents"><ol><li><a href="#%3E-title"> &gt; Title</a><ol><li><a href="#%3C-section"> &lt; Section</a></li><li><a href="#%3E-another-section"> &gt; Another Section</a></li></ol></li></ol></nav><h1 id="%3E-title"><a class="header-anchor" href="#%3E-title">§</a> &gt; Title</h1>
+test('especially < and >', () => {
+  const mdContent = '${toc}\n\n# > Title\n\n## < Section\n\n## > Another Section'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#%3E-title"> &gt; Title</a><ol><li><a href="#%3C-section"> &lt; Section</a></li><li><a href="#%3E-another-section"> &gt; Another Section</a></li></ol></li></ol></nav><h1 id="%3E-title"><a class="header-anchor" href="#%3E-title">§</a> &gt; Title</h1>
 <h2 id="%3C-section"><a class="header-anchor" href="#%3C-section">§</a> &lt; Section</h2>
 <h2 id="%3E-another-section"><a class="header-anchor" href="#%3E-another-section">§</a> &gt; Another Section</h2>
-`);
-});
+`
+  expect(commonMd.render(mdContent)).toBe(htmlContent)
+})
 
-test("skipping heading ranks should work", () => {
-	expect( md.render("${toc}\n\n## Foo\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus porta nulla id porttitor. Vivamus sagittis, leo eget gravida euismod, justo ex dignissim sem, in tempus turpis libero quis velit. Aliquam sit amet ultricies quam.\n\n#### Bar\nSuspendisse ornare pellentesque nibh non tristique. Suspendisse potenti. Nunc id dui non diam luctus imperdiet.\n\n## Grob\nQuisque fringilla urna sit amet elit ultrices tincidunt. Interdum et malesuada fames ac ante ipsum primis in faucibus. In posuere tellus suscipit sapien rhoncus euismod. Phasellus eu ligula mollis, finibus tortor ut, consectetur metus. Vestibulum eget leo felis.") ).toBe(`<nav class="table-of-contents"><ol><li><a href="#foo"> Foo</a><ol><li><a href="#bar"> Bar</a></li></ol></li><li><a href="#grob"> Grob</a></li></ol></nav><h2 id="foo"><a class="header-anchor" href="#foo">§</a> Foo</h2>
+test('skipping heading ranks should work', () => {
+  const mdContent = '${toc}\n\n## Foo\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus porta nulla id porttitor. Vivamus sagittis, leo eget gravida euismod, justo ex dignissim sem, in tempus turpis libero quis velit. Aliquam sit amet ultricies quam.\n\n#### Bar\nSuspendisse ornare pellentesque nibh non tristique. Suspendisse potenti. Nunc id dui non diam luctus imperdiet.\n\n## Grob\nQuisque fringilla urna sit amet elit ultrices tincidunt. Interdum et malesuada fames ac ante ipsum primis in faucibus. In posuere tellus suscipit sapien rhoncus euismod. Phasellus eu ligula mollis, finibus tortor ut, consectetur metus. Vestibulum eget leo felis.'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#foo"> Foo</a><ol><li><a href="#bar"> Bar</a></li></ol></li><li><a href="#grob"> Grob</a></li></ol></nav><h2 id="foo"><a class="header-anchor" href="#foo">§</a> Foo</h2>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus porta nulla id porttitor. Vivamus sagittis, leo eget gravida euismod, justo ex dignissim sem, in tempus turpis libero quis velit. Aliquam sit amet ultricies quam.</p>
 <h4 id="bar"><a class="header-anchor" href="#bar">§</a> Bar</h4>
 <p>Suspendisse ornare pellentesque nibh non tristique. Suspendisse potenti. Nunc id dui non diam luctus imperdiet.</p>
 <h2 id="grob"><a class="header-anchor" href="#grob">§</a> Grob</h2>
 <p>Quisque fringilla urna sit amet elit ultrices tincidunt. Interdum et malesuada fames ac ante ipsum primis in faucibus. In posuere tellus suscipit sapien rhoncus euismod. Phasellus eu ligula mollis, finibus tortor ut, consectetur metus. Vestibulum eget leo felis.</p>
-`);
+`
+  expect(commonMd.render(mdContent)).toBe(htmlContent)
 })
 
-test("code blocks should not be confused as headings", () => {
-	expect( md.render("[[_toc_]]\n\n## Foo\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus porta nulla id porttitor. Vivamus sagittis, leo eget gravida euismod, justo ex dignissim sem, in tempus turpis libero quis velit. Aliquam sit amet ultricies quam.\n\n#### Bar\nSuspendisse ornare pellentesque nibh non tristique. Suspendisse potenti. Nunc id dui non diam luctus imperdiet.\n\n    ## Grob\n    Quisque fringilla urna sit amet elit ultrices tincidunt. Interdum et malesuada fames ac ante ipsum primis in faucibus. In posuere tellus suscipit sapien rhoncus euismod. Phasellus eu ligula mollis, finibus tortor ut, consectetur metus. Vestibulum eget leo felis.") ).toBe(`<nav class="table-of-contents"><ol><li><a href="#foo"> Foo</a><ol><li><a href="#bar"> Bar</a></li></ol></li></ol></nav><h2 id="foo"><a class="header-anchor" href="#foo">§</a> Foo</h2>
+test('code blocks should not be confused as headings', () => {
+  const mdContent = '[[_toc_]]\n\n## Foo\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus porta nulla id porttitor. Vivamus sagittis, leo eget gravida euismod, justo ex dignissim sem, in tempus turpis libero quis velit. Aliquam sit amet ultricies quam.\n\n#### Bar\nSuspendisse ornare pellentesque nibh non tristique. Suspendisse potenti. Nunc id dui non diam luctus imperdiet.\n\n    ## Grob\n    Quisque fringilla urna sit amet elit ultrices tincidunt. Interdum et malesuada fames ac ante ipsum primis in faucibus. In posuere tellus suscipit sapien rhoncus euismod. Phasellus eu ligula mollis, finibus tortor ut, consectetur metus. Vestibulum eget leo felis.'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#foo"> Foo</a><ol><li><a href="#bar"> Bar</a></li></ol></li></ol></nav><h2 id="foo"><a class="header-anchor" href="#foo">§</a> Foo</h2>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus porta nulla id porttitor. Vivamus sagittis, leo eget gravida euismod, justo ex dignissim sem, in tempus turpis libero quis velit. Aliquam sit amet ultricies quam.</p>
 <h4 id="bar"><a class="header-anchor" href="#bar">§</a> Bar</h4>
 <p>Suspendisse ornare pellentesque nibh non tristique. Suspendisse potenti. Nunc id dui non diam luctus imperdiet.</p>
 <pre><code>## Grob
 Quisque fringilla urna sit amet elit ultrices tincidunt. Interdum et malesuada fames ac ante ipsum primis in faucibus. In posuere tellus suscipit sapien rhoncus euismod. Phasellus eu ligula mollis, finibus tortor ut, consectetur metus. Vestibulum eget leo felis.</code></pre>
-`);
-});
+`
+  expect(commonMd.render(mdContent)).toBe(htmlContent)
+})
 
-test("headers innerText may happen more than once", () => {
-	expect( md.render("[toc]\n\n# Title\n\n## Section 1\n\n### Subsection 1\n\n### Subsection 2\n\n## Section 2\n\n### Subsection 1\n\n### Subsection 2\n\n## Section 3\n\n### Subsection 1\n\n### Subsection 2") ).toBe(`<nav class="table-of-contents"><ol><li><a href="#title"> Title</a><ol><li><a href="#section-1"> Section 1</a><ol><li><a href="#subsection-1"> Subsection 1</a></li><li><a href="#subsection-2"> Subsection 2</a></li></ol></li><li><a href="#section-2"> Section 2</a><ol><li><a href="#subsection-1-2"> Subsection 1</a></li><li><a href="#subsection-2-2"> Subsection 2</a></li></ol></li><li><a href="#section-3"> Section 3</a><ol><li><a href="#subsection-1-3"> Subsection 1</a></li><li><a href="#subsection-2-3"> Subsection 2</a></li></ol></li></ol></li></ol></nav><h1 id="title"><a class="header-anchor" href="#title">§</a> Title</h1>
+test('headers innerText may happen more than once', () => {
+  const mdContent = '[toc]\n\n# Title\n\n## Section 1\n\n### Subsection 1\n\n### Subsection 2\n\n## Section 2\n\n### Subsection 1\n\n### Subsection 2\n\n## Section 3\n\n### Subsection 1\n\n### Subsection 2'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#title"> Title</a><ol><li><a href="#section-1"> Section 1</a><ol><li><a href="#subsection-1"> Subsection 1</a></li><li><a href="#subsection-2"> Subsection 2</a></li></ol></li><li><a href="#section-2"> Section 2</a><ol><li><a href="#subsection-1-2"> Subsection 1</a></li><li><a href="#subsection-2-2"> Subsection 2</a></li></ol></li><li><a href="#section-3"> Section 3</a><ol><li><a href="#subsection-1-3"> Subsection 1</a></li><li><a href="#subsection-2-3"> Subsection 2</a></li></ol></li></ol></li></ol></nav><h1 id="title"><a class="header-anchor" href="#title">§</a> Title</h1>
 <h2 id="section-1"><a class="header-anchor" href="#section-1">§</a> Section 1</h2>
 <h3 id="subsection-1"><a class="header-anchor" href="#subsection-1">§</a> Subsection 1</h3>
 <h3 id="subsection-2"><a class="header-anchor" href="#subsection-2">§</a> Subsection 2</h3>
@@ -152,33 +126,88 @@ test("headers innerText may happen more than once", () => {
 <h2 id="section-3"><a class="header-anchor" href="#section-3">§</a> Section 3</h2>
 <h3 id="subsection-1-3"><a class="header-anchor" href="#subsection-1-3">§</a> Subsection 1</h3>
 <h3 id="subsection-2-3"><a class="header-anchor" href="#subsection-2-3">§</a> Subsection 2</h3>
-`);
-});
+`
+  expect(commonMd.render(mdContent)).toBe(htmlContent)
+})
 
-test("and sometimes slugify with suffix may generate another existing header", () => {
-	expect( md.render("[[toc]]\n\n# header\n\n## header\n\n## header 2") ).toBe(`<nav class="table-of-contents"><ol><li><a href="#header"> header</a><ol><li><a href="#header-2"> header</a></li><li><a href="#header-2-2"> header 2</a></li></ol></li></ol></nav><h1 id="header"><a class="header-anchor" href="#header">§</a> header</h1>
+test('and sometimes slugify with suffix may generate another existing header', () => {
+  const mdContent = '[[toc]]\n\n# header\n\n## header\n\n## header 2'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#header"> header</a><ol><li><a href="#header-2"> header</a></li><li><a href="#header-2-2"> header 2</a></li></ol></li></ol></nav><h1 id="header"><a class="header-anchor" href="#header">§</a> header</h1>
 <h2 id="header-2"><a class="header-anchor" href="#header-2">§</a> header</h2>
 <h2 id="header-2-2"><a class="header-anchor" href="#header-2-2">§</a> header 2</h2>
-`);
-});
+`
+  expect(commonMd.render(mdContent)).toBe(htmlContent)
+})
 
-test("level(Int Type) option should work as expected", () => {
-	expect( level_md.render("${toc}\n\n# header\n\n## header\n\n## header 2") ).toBe(`<nav class="table-of-contents"><ol><li><a href="#header"> header</a></li><li><a href="#header-2"> header 2</a></li></ol></nav><h1>header</h1>
+test('containerId is set correctly', () => {
+  const md = getMarkdownIt()
+    .use(markdownItTocDoneRight, {
+      containerId: 'toc'
+    })
+  const mdContent = '${toc}'
+  const htmlContent = '<nav id="toc" class="table-of-contents"></nav>'
+  expect(md.render(mdContent)).toBe(htmlContent)
+})
+
+test('level(Int Type) option should work as expected', () => {
+  const md = getMarkdownIt()
+    .use(markdownItAnchor, {
+      permalink: true,
+      permalinkBefore: true,
+      permalinkSymbol: '§',
+      level: 2
+    })
+    .use(markdownItTocDoneRight, { level: 2 })
+  const mdContent = '${toc}\n\n# header\n\n## header\n\n## header 2'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#header"> header</a></li><li><a href="#header-2"> header 2</a></li></ol></nav><h1>header</h1>
 <h2 id="header"><a class="header-anchor" href="#header">§</a> header</h2>
 <h2 id="header-2"><a class="header-anchor" href="#header-2">§</a> header 2</h2>
-`);
-});
+`
+  expect(md.render(mdContent)).toBe(htmlContent)
+})
 
-test("level(Array Type) option should work as expected", () => {
-	expect( level_md_array.render("${toc}\n\n# header\n\n## header\n\n## header 2\n\n# header 4\n\n## header 5\n\n## header 2") ).toBe(`<nav class="table-of-contents"><ol><li><a href="#header"> header</a><ol><li><a href="#header-2"> header</a></li><li><a href="#header-2-2"> header 2</a></li></ol></li><li><a href="#header-4"> header 4</a><ol><li><a href="#header-5"> header 5</a></li><li><a href="#header-2-3"> header 2</a></li></ol></li></ol></nav><h1 id="header"><a class="header-anchor" href="#header">§</a> header</h1>
+test('level(Array Type) option should work as expected', () => {
+  const md = getMarkdownIt()
+    .use(markdownItAnchor, {
+      permalink: true,
+      permalinkBefore: true,
+      permalinkSymbol: '§',
+      level: [1, 2]
+    })
+    .use(markdownItTocDoneRight, { level: [1, 2] })
+  const mdContent = '${toc}\n\n# header\n\n## header\n\n## header 2\n\n# header 4\n\n## header 5\n\n## header 2'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#header"> header</a><ol><li><a href="#header-2"> header</a></li><li><a href="#header-2-2"> header 2</a></li></ol></li><li><a href="#header-4"> header 4</a><ol><li><a href="#header-5"> header 5</a></li><li><a href="#header-2-3"> header 2</a></li></ol></li></ol></nav><h1 id="header"><a class="header-anchor" href="#header">§</a> header</h1>
 <h2 id="header-2"><a class="header-anchor" href="#header-2">§</a> header</h2>
 <h2 id="header-2-2"><a class="header-anchor" href="#header-2-2">§</a> header 2</h2>
 <h1 id="header-4"><a class="header-anchor" href="#header-4">§</a> header 4</h1>
 <h2 id="header-5"><a class="header-anchor" href="#header-5">§</a> header 5</h2>
 <h2 id="header-2-3"><a class="header-anchor" href="#header-2-3">§</a> header 2</h2>
-`);
-});
+`
+  expect(md.render(mdContent)).toBe(htmlContent)
+})
 
-test("all other options should work as expected", () => {
-	expect( umd.render("@[[TOC]]\n\n# 日本語\n\n    # should be considered as code") ).toBe('<nav class="user-content-toc"><ul class="my-list"><li class="my-item"><a class="my-link" href="#日本語"><span> 日本語</span></a></li></ul></nav><h1 id="日本語"><a class="header-anchor" href="#日本語">§</a> 日本語</h1>\n<pre><code># should be considered as code</code></pre>\n');
-});
+test('all other options should work as expected', () => {
+  const md = getMarkdownIt()
+    .use(markdownItAnchor, {
+      permalink: true,
+      permalinkBefore: true,
+      permalinkSymbol: '§',
+      slugify: uslugify
+    })
+    .use(markdownItTocDoneRight, {
+      placeholder: '\\@\\[\\[TOC\\]\\]',
+      slugify: uslugify,
+      containerClass: 'user-content-toc',
+      listClass: 'my-list',
+      itemClass: 'my-item',
+      linkClass: 'my-link',
+      listType: 'ul',
+      format: customFormat,
+      callback: function (html, ast) {
+        console.log(ast)
+      }
+    })
+  const mdContent = '@[[TOC]]\n\n# 日本語\n\n    # should be considered as code'
+  const htmlContent = '<nav class="user-content-toc"><ul class="my-list"><li class="my-item"><a class="my-link" href="#日本語"><span> 日本語</span></a></li></ul></nav><h1 id="日本語"><a class="header-anchor" href="#日本語">§</a> 日本語</h1>\n<pre><code># should be considered as code</code></pre>\n'
+  expect(md.render(mdContent)).toBe(htmlContent)
+})

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "microbundle",
     "dev": "microbundle watch",
-    "lint": "standard --verbose index.js | snazzy",
+    "lint": "standard --verbose index.js __test__/test.js | snazzy",
     "test": "jest --coverage"
   },
   "repository": {


### PR DESCRIPTION
While working with markdown-it-toc-done-right, I had to find out that the test-spec is quite unordered and hard to read as it didn't follow any formatting standards.

This PR restructures the test file while keeping all tests with their original names and test values. The file now follows the same standard formatting as enforced for the index.js. It's therefore also included into the lint command.