### PR TITLE
Add option to set slugStartIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Name              | Description                                                 
 "listClass"       | The class for the `listType` HTMLElement                         | `undefined`
 "itemClass"       | The class for the LI                                             | `undefined`
 "linkClass"       | The class for the A                                              | `undefined`
+"slugStartIndex"  | The start index that should be appended to non-unique headings   | 1
 "level"           | Minimum level to apply anchors on or array of selected levels    | 1
 "listType"        | Type of list (`ul` for unordered, `ol` for ordered)              | `ol`
 "format"          | A function for formatting headings (see below)                   | `undefined`

--- a/__test__/test.js
+++ b/__test__/test.js
@@ -116,25 +116,25 @@ Quisque fringilla urna sit amet elit ultrices tincidunt. Interdum et malesuada f
 
 test('headers innerText may happen more than once', () => {
   const mdContent = '[toc]\n\n# Title\n\n## Section 1\n\n### Subsection 1\n\n### Subsection 2\n\n## Section 2\n\n### Subsection 1\n\n### Subsection 2\n\n## Section 3\n\n### Subsection 1\n\n### Subsection 2'
-  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#title"> Title</a><ol><li><a href="#section-1"> Section 1</a><ol><li><a href="#subsection-1"> Subsection 1</a></li><li><a href="#subsection-2"> Subsection 2</a></li></ol></li><li><a href="#section-2"> Section 2</a><ol><li><a href="#subsection-1-2"> Subsection 1</a></li><li><a href="#subsection-2-2"> Subsection 2</a></li></ol></li><li><a href="#section-3"> Section 3</a><ol><li><a href="#subsection-1-3"> Subsection 1</a></li><li><a href="#subsection-2-3"> Subsection 2</a></li></ol></li></ol></li></ol></nav><h1 id="title"><a class="header-anchor" href="#title">§</a> Title</h1>
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#title"> Title</a><ol><li><a href="#section-1"> Section 1</a><ol><li><a href="#subsection-1"> Subsection 1</a></li><li><a href="#subsection-2"> Subsection 2</a></li></ol></li><li><a href="#section-2"> Section 2</a><ol><li><a href="#subsection-1-1"> Subsection 1</a></li><li><a href="#subsection-2-1"> Subsection 2</a></li></ol></li><li><a href="#section-3"> Section 3</a><ol><li><a href="#subsection-1-2"> Subsection 1</a></li><li><a href="#subsection-2-2"> Subsection 2</a></li></ol></li></ol></li></ol></nav><h1 id="title"><a class="header-anchor" href="#title">§</a> Title</h1>
 <h2 id="section-1"><a class="header-anchor" href="#section-1">§</a> Section 1</h2>
 <h3 id="subsection-1"><a class="header-anchor" href="#subsection-1">§</a> Subsection 1</h3>
 <h3 id="subsection-2"><a class="header-anchor" href="#subsection-2">§</a> Subsection 2</h3>
 <h2 id="section-2"><a class="header-anchor" href="#section-2">§</a> Section 2</h2>
+<h3 id="subsection-1-1"><a class="header-anchor" href="#subsection-1-1">§</a> Subsection 1</h3>
+<h3 id="subsection-2-1"><a class="header-anchor" href="#subsection-2-1">§</a> Subsection 2</h3>
+<h2 id="section-3"><a class="header-anchor" href="#section-3">§</a> Section 3</h2>
 <h3 id="subsection-1-2"><a class="header-anchor" href="#subsection-1-2">§</a> Subsection 1</h3>
 <h3 id="subsection-2-2"><a class="header-anchor" href="#subsection-2-2">§</a> Subsection 2</h3>
-<h2 id="section-3"><a class="header-anchor" href="#section-3">§</a> Section 3</h2>
-<h3 id="subsection-1-3"><a class="header-anchor" href="#subsection-1-3">§</a> Subsection 1</h3>
-<h3 id="subsection-2-3"><a class="header-anchor" href="#subsection-2-3">§</a> Subsection 2</h3>
 `
   expect(commonMd.render(mdContent)).toBe(htmlContent)
 })
 
 test('and sometimes slugify with suffix may generate another existing header', () => {
-  const mdContent = '[[toc]]\n\n# header\n\n## header\n\n## header 2'
-  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#header"> header</a><ol><li><a href="#header-2"> header</a></li><li><a href="#header-2-2"> header 2</a></li></ol></li></ol></nav><h1 id="header"><a class="header-anchor" href="#header">§</a> header</h1>
-<h2 id="header-2"><a class="header-anchor" href="#header-2">§</a> header</h2>
-<h2 id="header-2-2"><a class="header-anchor" href="#header-2-2">§</a> header 2</h2>
+  const mdContent = '[[toc]]\n\n# header\n\n## header\n\n## header 1'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#header"> header</a><ol><li><a href="#header-1"> header</a></li><li><a href="#header-1-1"> header 1</a></li></ol></li></ol></nav><h1 id="header"><a class="header-anchor" href="#header">§</a> header</h1>
+<h2 id="header-1"><a class="header-anchor" href="#header-1">§</a> header</h2>
+<h2 id="header-1-1"><a class="header-anchor" href="#header-1-1">§</a> header 1</h2>
 `
   expect(commonMd.render(mdContent)).toBe(htmlContent)
 })
@@ -175,13 +175,30 @@ test('level(Array Type) option should work as expected', () => {
       level: [1, 2]
     })
     .use(markdownItTocDoneRight, { level: [1, 2] })
-  const mdContent = '${toc}\n\n# header\n\n## header\n\n## header 2\n\n# header 4\n\n## header 5\n\n## header 2'
-  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#header"> header</a><ol><li><a href="#header-2"> header</a></li><li><a href="#header-2-2"> header 2</a></li></ol></li><li><a href="#header-4"> header 4</a><ol><li><a href="#header-5"> header 5</a></li><li><a href="#header-2-3"> header 2</a></li></ol></li></ol></nav><h1 id="header"><a class="header-anchor" href="#header">§</a> header</h1>
-<h2 id="header-2"><a class="header-anchor" href="#header-2">§</a> header</h2>
-<h2 id="header-2-2"><a class="header-anchor" href="#header-2-2">§</a> header 2</h2>
+  const mdContent = '${toc}\n\n# header\n\n## header\n\n## header 1\n\n# header 4\n\n## header 5\n\n## header 1'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#header"> header</a><ol><li><a href="#header-1"> header</a></li><li><a href="#header-1-1"> header 1</a></li></ol></li><li><a href="#header-4"> header 4</a><ol><li><a href="#header-5"> header 5</a></li><li><a href="#header-1-2"> header 1</a></li></ol></li></ol></nav><h1 id="header"><a class="header-anchor" href="#header">§</a> header</h1>
+<h2 id="header-1"><a class="header-anchor" href="#header-1">§</a> header</h2>
+<h2 id="header-1-1"><a class="header-anchor" href="#header-1-1">§</a> header 1</h2>
 <h1 id="header-4"><a class="header-anchor" href="#header-4">§</a> header 4</h1>
 <h2 id="header-5"><a class="header-anchor" href="#header-5">§</a> header 5</h2>
-<h2 id="header-2-3"><a class="header-anchor" href="#header-2-3">§</a> header 2</h2>
+<h2 id="header-1-2"><a class="header-anchor" href="#header-1-2">§</a> header 1</h2>
+`
+  expect(md.render(mdContent)).toBe(htmlContent)
+})
+
+test('slugStartIndex set to 0', () => {
+  const md = getMarkdownIt()
+    .use(markdownItAnchor, {
+      permalink: true,
+      permalinkBefore: true,
+      permalinkSymbol: '§',
+      level: [1, 2],
+      uniqueSlugStartIndex: 0
+    })
+    .use(markdownItTocDoneRight, { slugStartIndex: 0 })
+  const mdContent = '[toc]\n\n# header\n\n## header'
+  const htmlContent = `<nav class="table-of-contents"><ol><li><a href="#header"> header</a><ol><li><a href="#header-0"> header</a></li></ol></li></ol></nav><h1 id="header"><a class="header-anchor" href="#header">§</a> header</h1>
+<h2 id="header-0"><a class="header-anchor" href="#header-0">§</a> header</h2>
 `
   expect(md.render(mdContent)).toBe(htmlContent)
 })
@@ -192,11 +209,13 @@ test('all other options should work as expected', () => {
       permalink: true,
       permalinkBefore: true,
       permalinkSymbol: '§',
+      uniqueSlugStartIndex: 2,
       slugify: uslugify
     })
     .use(markdownItTocDoneRight, {
       placeholder: '\\@\\[\\[TOC\\]\\]',
       slugify: uslugify,
+      slugStartIndex: 2,
       containerClass: 'user-content-toc',
       listClass: 'my-list',
       itemClass: 'my-item',
@@ -207,7 +226,7 @@ test('all other options should work as expected', () => {
         console.log(ast)
       }
     })
-  const mdContent = '@[[TOC]]\n\n# 日本語\n\n    # should be considered as code'
-  const htmlContent = '<nav class="user-content-toc"><ul class="my-list"><li class="my-item"><a class="my-link" href="#日本語"><span> 日本語</span></a></li></ul></nav><h1 id="日本語"><a class="header-anchor" href="#日本語">§</a> 日本語</h1>\n<pre><code># should be considered as code</code></pre>\n'
+  const mdContent = '@[[TOC]]\n\n# 日本語\n\n# 日本語\n\n    # should be considered as code'
+  const htmlContent = '<nav class="user-content-toc"><ul class="my-list"><li class="my-item"><a class="my-link" href="#日本語"><span> 日本語</span></a></li><li class="my-item"><a class="my-link" href="#日本語-2"><span> 日本語</span></a></li></ul></nav><h1 id="日本語"><a class="header-anchor" href="#日本語">§</a> 日本語</h1>\n<h1 id="日本語-2"><a class="header-anchor" href="#日本語-2">§</a> 日本語</h1>\n<pre><code># should be considered as code</code></pre>\n'
   expect(md.render(mdContent)).toBe(htmlContent)
 })

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function tocPlugin (md, options) {
     linkClass: undefined,
     level: 1,
     listType: 'ol',
+    slugStartIndex: 1,
     format: undefined,
     callback: undefined/* function(html, ast) {} */
   }, options)
@@ -105,7 +106,7 @@ function tocPlugin (md, options) {
     const uniques = {}
     function unique (s) {
       let u = s
-      let i = 2
+      let i = _options.slugStartIndex
       while (Object.prototype.hasOwnProperty.call(uniques, u)) u = `${s}-${i++}`
       uniques[u] = true
       return u

--- a/package-lock.json
+++ b/package-lock.json
@@ -775,6 +775,28 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/linkify-it": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-2.1.0.tgz",
+      "integrity": "sha512-Q7DYAOi9O/+cLLhdaSvKdaumWyHbm7HAk/bFwwyTuU0arR5yyCeW5GOoqt4tJTpDRxhpx9Q8kQL6vMpuw9hDSw==",
+      "dev": true
+    },
+    "@types/markdown-it": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-10.0.2.tgz",
+      "integrity": "sha512-FGKiVW1UgeIEAChYAuHcfCd0W4LsMEyrSyTVaZiuJhwR4BwSVUD8JKnzmWAMK2FHNLZSPGUaEkpa/dkZj2uq1w==",
+      "dev": true,
+      "requires": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "12.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.2.tgz",
@@ -5997,9 +6019,9 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.5.tgz",
-      "integrity": "sha512-xLIjLQmtym3QpoY9llBgApknl7pxAcN3WDRc2d3rwpl+/YvDZHPmKscGs+L6E05xf2KrCXPBvosWt7MZukwSpQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-6.0.0.tgz",
+      "integrity": "sha512-WOcIGhG1M1W94VV5cmSZAMSKi2vqCxpLAqQZ0wSO9RzQ9Rbls7ecjRVXp5DIPoXrNy9bjv9K7M0nYqNk60ctxQ==",
       "dev": true
     },
     "math-expression-evaluator": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jest": "^24.9.0",
     "markdown-it": "^10.0.0",
     "@types/markdown-it": "^10.0.0",
-    "markdown-it-anchor": "^5.2.5",
+    "markdown-it-anchor": "^6.0.0",
     "microbundle": "^0.11.0",
     "snazzy": "^8.0.0",
     "standard": "^13.1.0",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,7 @@ declare module 'markdown-it-toc-done-right' {
     export interface TocOptions {
         placeholder: string
         slugify: (s: string) => string
+        slugStartIndex: number
         containerClass: string
         containerId: string
         listClass: string


### PR DESCRIPTION
~~Note: This PR is based on #39, which should be merged prior to this one.~~ (done)

This PR adds the option `slugStartIndex` that allows to define a custom number to start the counting of suffixes for duplicate headings.

~~If #40 is merged before this, I will add the change in types of course with this PR too.~~ (done)

Breaking: This PR sets the default value for slugStartIndex to 1 to be compatible with markdown-it-anchor v6 out of the box.

Example:
```markdown
# heading
# heading
```

will now result in something like this (note the suffix "-1" instead of "-2").
```html
<!-- this is only a snippet -->
<nav>
<ul>
<li><a href="#heading">heading</a></li>
<li><a href="#heading-1">heading</a></li>
</ul>
</nav>
```

Fixes #38 