### PR TITLE
FIX: typo that made browser example invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ var md = window.markdownit({
 	html: false,
 	xhtmlOut: true,
 	typographer: true
-}).use( window.markdownitAnchor, { permalink: true, permalinkBefore: true, permalinkSymbol: '§' } )
-  .use( window.markdownitTocDoneRight );
+}).use( window.markdownItAnchor, { permalink: true, permalinkBefore: true, permalinkSymbol: '§' } )
+  .use( window.markdownItTocDoneRight );
 
 var result = md.render("# markdown-it rulezz!\n\n${toc}\n## with markdown-it-toc-done-right rulezz even more!");
 ```


### PR DESCRIPTION
When you load the required scripts, eg:

```html
<script src="https://cdn.jsdelivr.net/npm/markdown-it@12.0.3/dist/markdown-it.min.js"></script>
<script src="https://unpkg.com/markdown-it-anchor/dist/markdownItAnchor.umd.js"></script>
<script src="https://unpkg.com/markdown-it-toc-done-right/dist/markdownItTocDoneRight.umd.js"></script>
```

The `markdownItAnchor` and `markdownItTocDoneRight` are defined as `window.markdownItAnchor` and `window.markdownItTocDoneRight`, with the `i` of markdown**i**t uppercased.

This typo makes the current code fail, but this PR fixes it accordingly.