### PR TITLE
types: fix import

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'markdown-it-toc-done-right' {
-    import MarkdownIt from 'markdown-it/lib'
+    import { PluginWithOptions } from 'markdown-it';
 
     export interface TocOptions {
         placeholder: string
@@ -22,7 +22,7 @@ declare module 'markdown-it-toc-done-right' {
         c: TocAst[]
     }
 
-    const markdownItTocDoneRight: MarkdownIt.PluginWithOptions<Partial<TocOptions>>
+    const markdownItTocDoneRight: PluginWithOptions<Partial<TocOptions>>
 
     export default markdownItTocDoneRight
 }


### PR DESCRIPTION
This fixes the import of types from `markdown-it`.

`@types/markdown-it` doesn't provide default exports, so I got an error saying something like: `Module '"/path/to/@types/markdown-it/index"' can only be default-imported using the 'esModuleInterop' flag`. (And yes, I had `esModuleInterop` activated in my tsconfig)

I fixed it by importing only `PluginWithOptions`. I don't really understand why this works (and didn't before) but it works so I think it's ok. It should work on all TypeScript build targets.